### PR TITLE
Scaffold FA Fundraising plugin

### DIFF
--- a/wp-content/plugins/fa-fundraising/composer.json
+++ b/wp-content/plugins/fa-fundraising/composer.json
@@ -1,0 +1,12 @@
+{
+  "name": "futureachievers/fa-fundraising",
+  "type": "wordpress-plugin",
+  "require": {
+    "php": ">=8.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "FA\\Fundraising\\": "src/"
+    }
+  }
+}

--- a/wp-content/plugins/fa-fundraising/fa-fundraising.php
+++ b/wp-content/plugins/fa-fundraising/fa-fundraising.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Plugin Name: Future Achievers Fundraising
+ * Description: Standalone fundraising engine (Razorpay-ready) with donor dashboard and receipts.
+ * Version: 0.1.0
+ * Author: Future Achievers
+ * Text Domain: fa-fundraising
+ */
+
+if (!defined('ABSPATH')) exit;
+
+define('FAF_VERSION', '0.1.0');
+define('FAF_FILE', __FILE__);
+define('FAF_PATH', plugin_dir_path(__FILE__));
+define('FAF_URL', plugin_dir_url(__FILE__));
+
+/** Composer autoload (recommended) */
+$autoload = FAF_PATH . 'vendor/autoload.php';
+if (file_exists($autoload)) {
+    require_once $autoload;
+}
+
+/** Fallback simple autoloader (if composer not used yet) */
+spl_autoload_register(function($class){
+    if (strpos($class, 'FA\\Fundraising\\') !== 0) return;
+    $path = FAF_PATH . 'src/' . str_replace(['FA\\Fundraising\\','\\'], ['','/'], $class) . '.php';
+    if (file_exists($path)) require_once $path;
+});
+
+use FA\Fundraising\Bootstrap;
+use FA\Fundraising\Setup\Activator;
+
+register_activation_hook(__FILE__, [Activator::class, 'activate']);
+register_deactivation_hook(__FILE__, [Activator::class, 'deactivate']);
+register_uninstall_hook(__FILE__, ['FA\\Fundraising\\Setup\\Activator', 'uninstall']);
+
+add_action('plugins_loaded', function(){
+    (new Bootstrap())->init();
+});

--- a/wp-content/plugins/fa-fundraising/src/Bootstrap.php
+++ b/wp-content/plugins/fa-fundraising/src/Bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+namespace FA\Fundraising;
+
+if (!defined('ABSPATH')) exit;
+
+class Bootstrap {
+    public function init(): void
+    {
+        // i18n
+        add_action('init', function(){
+            load_plugin_textdomain('fa-fundraising', false, dirname(plugin_basename(FAF_FILE)).'/languages');
+        });
+
+        // Shortcodes (placeholders for now)
+        (new \FA\Fundraising\Shortcodes\DonorShortcodes())->register();
+
+        // Minimal REST namespace (we’ll add routes later)
+        add_action('rest_api_init', function(){
+            register_rest_route('faf/v1', '/ping', [
+                'methods'  => 'GET',
+                'callback' => fn() => ['ok' => true, 'version' => FAF_VERSION],
+                'permission_callback' => '__return_true'
+            ]);
+        });
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Setup/Activator.php
+++ b/wp-content/plugins/fa-fundraising/src/Setup/Activator.php
@@ -1,0 +1,175 @@
+<?php
+namespace FA\Fundraising\Setup;
+
+use wpdb;
+
+if (!defined('ABSPATH')) exit;
+
+class Activator {
+
+    public static function activate(): void
+    {
+        self::check_requirements();
+        self::create_tables();
+        self::add_roles_caps();
+        self::create_frontend_pages();
+        flush_rewrite_rules();
+    }
+
+    public static function deactivate(): void
+    {
+        flush_rewrite_rules();
+    }
+
+    public static function uninstall(): void
+    {
+        // Data retention is usually required for NGO finance — do NOT drop tables.
+        // If you ever need to, guard with confirmations and options flags.
+    }
+
+    private static function check_requirements(): void
+    {
+        if (version_compare(PHP_VERSION, '8.1', '<')) {
+            deactivate_plugins(plugin_basename(FAF_FILE));
+            wp_die('Future Achievers Fundraising requires PHP 8.1+');
+        }
+        global $wp_version;
+        if (version_compare($wp_version, '6.5', '<')) {
+            deactivate_plugins(plugin_basename(FAF_FILE));
+            wp_die('Future Achievers Fundraising requires WordPress 6.5+');
+        }
+    }
+
+    private static function create_tables(): void
+    {
+        global $wpdb;
+        require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        $charset = $wpdb->get_charset_collate();
+
+        $donations = $wpdb->prefix . 'fa_donations';
+        $sponsorships = $wpdb->prefix . 'fa_sponsorships';
+        $subscriptions = $wpdb->prefix . 'fa_subscriptions';
+
+        $sql1 = "CREATE TABLE {$donations} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            user_id BIGINT UNSIGNED NULL,
+            donor_name VARCHAR(191) NULL,
+            donor_email VARCHAR(191) NULL,
+            phone VARCHAR(32) NULL,
+            amount DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+            currency VARCHAR(10) NOT NULL DEFAULT 'INR',
+            type VARCHAR(20) NOT NULL DEFAULT 'general',
+            orphan_id BIGINT UNSIGNED NULL,
+            cause_id BIGINT UNSIGNED NULL,
+            razorpay_payment_id VARCHAR(64) NULL,
+            razorpay_order_id VARCHAR(64) NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'pending',
+            financial_year VARCHAR(16) NULL,
+            receipt_no VARCHAR(32) NULL,
+            receipt_pdf VARCHAR(255) NULL,
+            receipt80g_pdf VARCHAR(255) NULL,
+            verify_hash VARCHAR(64) NULL,
+            meta LONGTEXT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY uniq_payment_id (razorpay_payment_id),
+            KEY idx_order_id (razorpay_order_id),
+            KEY idx_status (status),
+            KEY idx_user (user_id),
+            KEY idx_orphan (orphan_id),
+            KEY idx_cause (cause_id),
+            KEY idx_fy_receipt (financial_year, receipt_no)
+        ) $charset;";
+
+        $sql2 = "CREATE TABLE {$sponsorships} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            orphan_id BIGINT UNSIGNED NOT NULL,
+            user_id BIGINT UNSIGNED NULL,
+            donor_email VARCHAR(191) NULL,
+            donor_name VARCHAR(191) NULL,
+            phone VARCHAR(32) NULL,
+            slot_no INT UNSIGNED NULL,
+            periodicity VARCHAR(12) NOT NULL DEFAULT 'monthly',
+            amount DECIMAL(12,2) NOT NULL DEFAULT 0.00,
+            start_date DATE NULL,
+            next_charge_on DATE NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'active',
+            meta LONGTEXT NULL,
+            PRIMARY KEY  (id),
+            KEY idx_orphan (orphan_id),
+            KEY idx_user (user_id),
+            KEY idx_status (status)
+        ) $charset;";
+
+        $sql3 = "CREATE TABLE {$subscriptions} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            razorpay_subscription_id VARCHAR(64) NOT NULL,
+            user_id BIGINT UNSIGNED NULL,
+            donor_email VARCHAR(191) NULL,
+            plan_id VARCHAR(64) NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'active',
+            current_start DATETIME NULL,
+            current_end DATETIME NULL,
+            notes LONGTEXT NULL,
+            PRIMARY KEY  (id),
+            UNIQUE KEY uniq_sub (razorpay_subscription_id),
+            KEY idx_user (user_id),
+            KEY idx_status (status)
+        ) $charset;";
+
+        dbDelta($sql1);
+        dbDelta($sql2);
+        dbDelta($sql3);
+    }
+
+    private static function add_roles_caps(): void
+    {
+        // Donor (front-end only)
+        add_role('fa_donor', __('FA Donor','fa-fundraising'), ['read' => true]);
+
+        // Managers (wp-admin)
+        $manager_caps = [
+            'read' => true,
+            'list_users' => true,
+            'edit_users' => true,
+            'manage_options' => true
+        ];
+        add_role('fa_manager', __('FA Manager','fa-fundraising'), $manager_caps);
+
+        // Accountant (limited)
+        $acct_caps = [
+            'read' => true,
+            'list_users' => true
+        ];
+        add_role('fa_accountant', __('FA Accountant','fa-fundraising'), $acct_caps);
+    }
+
+    private static function create_frontend_pages(): void
+    {
+        $pages = [
+            'fa_donor_login_page_id'     => ['title' => 'Donor Login',     'slug' => 'donor-login',     'shortcode' => '[fa_donor_login]'],
+            'fa_donor_dashboard_page_id' => ['title' => 'Donor Dashboard', 'slug' => 'donor-dashboard', 'shortcode' => '[fa_donor_dashboard]'],
+            'fa_donor_receipts_page_id'  => ['title' => 'My Receipts',     'slug' => 'donor-receipts',  'shortcode' => '[fa_receipts]'],
+            'fa_donor_settings_page_id'  => ['title' => 'My Settings',     'slug' => 'donor-settings',  'shortcode' => '[fa_donor_settings]'],
+        ];
+
+        foreach ($pages as $option_key => $data) {
+            $existing = get_option($option_key);
+            if ($existing && get_post_status((int)$existing)) continue;
+
+            $pid = wp_insert_post([
+                'post_title'   => wp_strip_all_tags($data['title']),
+                'post_name'    => sanitize_title($data['slug']),
+                'post_status'  => 'publish',
+                'post_type'    => 'page',
+                'post_content' => $data['shortcode']
+            ]);
+            if ($pid && !is_wp_error($pid)) {
+                update_option($option_key, (int)$pid);
+            }
+        }
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Shortcodes/DonorShortcodes.php
+++ b/wp-content/plugins/fa-fundraising/src/Shortcodes/DonorShortcodes.php
@@ -1,0 +1,77 @@
+<?php
+namespace FA\Fundraising\Shortcodes;
+
+if (!defined('ABSPATH')) exit;
+
+class DonorShortcodes {
+
+    public function register(): void
+    {
+        add_shortcode('fa_donor_login', [$this, 'login']);
+        add_shortcode('fa_donor_dashboard', [$this, 'dashboard']);
+        add_shortcode('fa_receipts', [$this, 'receipts']);
+        add_shortcode('fa_donor_settings', [$this, 'settings']);
+    }
+
+    public function login($atts = [], $content = ''): string
+    {
+        // Placeholder UI (Elementor widget will replace later)
+        ob_start(); ?>
+        <div class="fa-card">
+            <h3><?php esc_html_e('Donor Login','fa-fundraising'); ?></h3>
+            <p><?php esc_html_e('Email-based login coming in Step 2 (Magic Link / OTP).','fa-fundraising'); ?></p>
+        </div>
+        <?php return ob_get_clean();
+    }
+
+    public function dashboard($atts = [], $content = ''): string
+    {
+        if (!is_user_logged_in()) {
+            return sprintf('<p>%s <a href="%s">%s</a></p>',
+                esc_html__('Please log in to view your dashboard.','fa-fundraising'),
+                esc_url(get_permalink((int) get_option('fa_donor_login_page_id'))),
+                esc_html__('Login','fa-fundraising')
+            );
+        }
+        ob_start(); ?>
+        <div class="fa-card">
+            <h3><?php esc_html_e('My Dashboard','fa-fundraising'); ?></h3>
+            <p><?php esc_html_e('KPI cards, charts, and tables will appear here in later steps.','fa-fundraising'); ?></p>
+        </div>
+        <?php return ob_get_clean();
+    }
+
+    public function receipts($atts = [], $content = ''): string
+    {
+        if (!is_user_logged_in()) {
+            return sprintf('<p>%s <a href="%s">%s</a></p>',
+                esc_html__('Please log in to view your receipts.','fa-fundraising'),
+                esc_url(get_permalink((int) get_option('fa_donor_login_page_id'))),
+                esc_html__('Login','fa-fundraising')
+            );
+        }
+        ob_start(); ?>
+        <div class="fa-card">
+            <h3><?php esc_html_e('My Receipts','fa-fundraising'); ?></h3>
+            <p><?php esc_html_e('Receipt list and downloads will appear here.','fa-fundraising'); ?></p>
+        </div>
+        <?php return ob_get_clean();
+    }
+
+    public function settings($atts = [], $content = ''): string
+    {
+        if (!is_user_logged_in()) {
+            return sprintf('<p>%s <a href="%s">%s</a></p>',
+                esc_html__('Please log in to edit your settings.','fa-fundraising'),
+                esc_url(get_permalink((int) get_option('fa_donor_login_page_id'))),
+                esc_html__('Login','fa-fundraising')
+            );
+        }
+        ob_start(); ?>
+        <div class="fa-card">
+            <h3><?php esc_html_e('My Settings','fa-fundraising'); ?></h3>
+            <p><?php esc_html_e('Profile, PAN, address, privacy tools coming soon.','fa-fundraising'); ?></p>
+        </div>
+        <?php return ob_get_clean();
+    }
+}


### PR DESCRIPTION
## Summary
- add initial FA Fundraising plugin with metadata, autoloading, and activation hooks
- bootstrap plugin with text domain loading, donor shortcodes, and REST ping route
- implement activator to create custom DB tables, roles, and donor-facing pages
- add placeholder donor dashboard, receipts, login, and settings shortcodes

## Testing
- `composer validate --no-check-all --strict --working-dir wp-content/plugins/fa-fundraising`
- `find wp-content/plugins/fa-fundraising -name "*.php" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_68b14bc336c083259a44a47d9d272b31