### PR TITLE
Add Razorpay settings and webhook support

### DIFF
--- a/wp-content/plugins/fa-fundraising/composer.json
+++ b/wp-content/plugins/fa-fundraising/composer.json
@@ -3,7 +3,8 @@
   "type": "wordpress-plugin",
   "require": {
     "php": ">=8.1",
-    "dompdf/dompdf": "^2.0"
+    "dompdf/dompdf": "^2.0",
+    "razorpay/razorpay": "^3.0"
   },
   "autoload": {
     "psr-4": {

--- a/wp-content/plugins/fa-fundraising/src/Admin/Settings.php
+++ b/wp-content/plugins/fa-fundraising/src/Admin/Settings.php
@@ -1,0 +1,54 @@
+<?php
+namespace FA\Fundraising\Admin;
+
+if (!defined('ABSPATH')) exit;
+
+class Settings {
+    public function init(): void {
+        add_action('admin_menu', function(){
+            add_menu_page(
+                __('FA Fundraising','fa-fundraising'),
+                'FA Fundraising',
+                'manage_options',
+                'fa-fundraising',
+                [$this,'render'],
+                'dashicons-heart',
+                58
+            );
+        });
+        add_action('admin_init', function(){
+            register_setting('fa_fundraising', 'fa_rzp_key_id');
+            register_setting('fa_fundraising', 'fa_rzp_key_secret');
+            register_setting('fa_fundraising', 'fa_rzp_webhook_secret');
+            register_setting('fa_fundraising', 'fa_org_address'); // optional for PDFs
+            register_setting('fa_fundraising', 'fa_org_logo_url');
+            register_setting('fa_fundraising', 'fa_org_pan');
+            register_setting('fa_fundraising', 'fa_org_80g_reg');
+        });
+    }
+
+    public function render(): void {
+        ?>
+        <div class="wrap">
+          <h1><?php esc_html_e('Future Achievers Fundraising - Settings','fa-fundraising'); ?></h1>
+          <form method="post" action="options.php">
+            <?php settings_fields('fa_fundraising'); ?>
+            <table class="form-table" role="presentation">
+              <tr><th><label>Razorpay Key ID</label></th><td><input type="text" name="fa_rzp_key_id" value="<?php echo esc_attr(get_option('fa_rzp_key_id','')); ?>" class="regular-text"></td></tr>
+              <tr><th><label>Razorpay Key Secret</label></th><td><input type="password" name="fa_rzp_key_secret" value="<?php echo esc_attr(get_option('fa_rzp_key_secret','')); ?>" class="regular-text"></td></tr>
+              <tr><th><label>Webhook Secret</label></th><td><input type="text" name="fa_rzp_webhook_secret" value="<?php echo esc_attr(get_option('fa_rzp_webhook_secret','')); ?>" class="regular-text"></td></tr>
+            </table>
+            <h2 class="title">Receipt/Org Details (optional for PDFs)</h2>
+            <table class="form-table" role="presentation">
+              <tr><th><label>Org Address</label></th><td><textarea name="fa_org_address" class="large-text" rows="3"><?php echo esc_textarea(get_option('fa_org_address','')); ?></textarea></td></tr>
+              <tr><th><label>Org Logo URL</label></th><td><input type="text" name="fa_org_logo_url" value="<?php echo esc_attr(get_option('fa_org_logo_url','')); ?>" class="regular-text"></td></tr>
+              <tr><th><label>Org PAN</label></th><td><input type="text" name="fa_org_pan" value="<?php echo esc_attr(get_option('fa_org_pan','')); ?>" class="regular-text"></td></tr>
+              <tr><th><label>80G Registration No.</label></th><td><input type="text" name="fa_org_80g_reg" value="<?php echo esc_attr(get_option('fa_org_80g_reg','')); ?>" class="regular-text"></td></tr>
+            </table>
+            <?php submit_button(); ?>
+          </form>
+          <p><strong>Webhook URL:</strong> <?php echo esc_url( rest_url('faf/v1/webhook/razorpay') ); ?></p>
+        </div>
+        <?php
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Api/CheckoutController.php
+++ b/wp-content/plugins/fa-fundraising/src/Api/CheckoutController.php
@@ -1,0 +1,68 @@
+<?php
+namespace FA\Fundraising\Api;
+
+use FA\Fundraising\Payments\RazorpayService;
+
+if (!defined('ABSPATH')) exit;
+
+class CheckoutController {
+    public function init(): void {
+        add_action('rest_api_init', function(){
+            register_rest_route('faf/v1','/checkout/order',[
+                'methods'=>'POST',
+                'callback'=>[$this,'create_order'],
+                'permission_callback'=>'__return_true'
+            ]);
+        });
+    }
+
+    public function create_order(\WP_REST_Request $req) {
+        $p = $req->get_json_params() ?: [];
+        $amount   = isset($p['amount']) ? (float)$p['amount'] : 0.0;
+        $currency = $p['currency'] ?? 'INR';
+        $type     = sanitize_text_field($p['type'] ?? 'general'); // general|cause|sponsorship
+        $orphan_id= isset($p['orphan_id']) ? (int)$p['orphan_id'] : null;
+        $cause_id = isset($p['cause_id']) ? (int)$p['cause_id'] : null;
+
+        $email = sanitize_email($p['email'] ?? '');
+        $name  = sanitize_text_field($p['name'] ?? '');
+        $phone = preg_replace('/[^0-9+]/','', (string)($p['phone'] ?? ''));
+
+        if ($amount <= 0 || !$email) {
+            return new \WP_Error('bad','Amount and email required',['status'=>400]);
+        }
+
+        // ensure a donor user exists
+        $user_id = self::get_or_create_donor_user($email, $name);
+
+        $rzp = new RazorpayService();
+        $notes = [
+            'type' => $type,
+            'orphan_id' => $orphan_id ?: '',
+            'cause_id' => $cause_id ?: '',
+            'donor_email' => $email,
+            'donor_name'  => $name,
+            'user_id' => (string)$user_id,
+            'phone'   => $phone
+        ];
+        $order = $rzp->create_order($amount, $currency, $notes);
+        return [
+            'ok'=>true,
+            'key_id'=>$rzp->keyId(),
+            'order'=>$order
+        ];
+    }
+
+    private static function get_or_create_donor_user(string $email, string $name=''): int {
+        $u = get_user_by('email', $email);
+        if ($u) return (int)$u->ID;
+        $username = sanitize_user(current(explode('@',$email)).'_'.wp_generate_password(6,false,false), true);
+        $pass = wp_generate_password(20, true, true);
+        $uid  = wp_create_user($username, $pass, $email);
+        if (is_wp_error($uid)) return 0;
+        $wu = new \WP_User($uid);
+        $wu->set_role('fa_donor');
+        if ($name) wp_update_user(['ID'=>$uid,'display_name'=>$name]);
+        return (int)$uid;
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Bootstrap.php
+++ b/wp-content/plugins/fa-fundraising/src/Bootstrap.php
@@ -18,6 +18,9 @@ class Bootstrap {
 
         (new \FA\Fundraising\Api\StatsController())->init();
         (new \FA\Fundraising\Api\DonationController())->init();
+        (new \FA\Fundraising\Api\CheckoutController())->init();
+        (new \FA\Fundraising\Admin\Settings())->init();
+        (new \FA\Fundraising\Payments\WebhookController())->init();
 
         (new \FA\Fundraising\Widgets\Elementor\Plugin())->init();
 

--- a/wp-content/plugins/fa-fundraising/src/Payments/RazorpayService.php
+++ b/wp-content/plugins/fa-fundraising/src/Payments/RazorpayService.php
@@ -1,0 +1,50 @@
+<?php
+namespace FA\Fundraising\Payments;
+
+use Razorpay\Api\Api;
+
+if (!defined('ABSPATH')) exit;
+
+class RazorpayService {
+    private string $key_id;
+    private string $key_secret;
+    private string $webhook_secret;
+
+    public function __construct() {
+        $this->key_id        = (string) get_option('fa_rzp_key_id', '');
+        $this->key_secret    = (string) get_option('fa_rzp_key_secret', '');
+        $this->webhook_secret= (string) get_option('fa_rzp_webhook_secret', '');
+    }
+
+    public function keyId(): string { return $this->key_id; }
+
+    private function api(): Api {
+        return new Api($this->key_id, $this->key_secret);
+    }
+
+    /** $amount_rupees decimal(2), returns Razorpay order array */
+    public function create_order(float $amount_rupees, string $currency='INR', array $notes=[]): array {
+        $a_paise = (int) round($amount_rupees * 100);
+        $receipt = 'FA-'.time().'-'.wp_generate_password(6,false,false);
+        $order = $this->api()->order->create([
+            'amount' => $a_paise,
+            'currency' => $currency,
+            'receipt' => $receipt,
+            'payment_capture' => 1,
+            'notes' => $notes,
+        ]);
+        return $order->toArray();
+    }
+
+    /** Verify webhook signature, throws on mismatch */
+    public function verify_webhook(string $payload, string $sig): void {
+        $this->api()->utility->verifyWebhookSignature($payload, $sig, $this->webhook_secret);
+    }
+
+    public static function fy_from_date(string $date): string {
+        $t = strtotime($date);
+        $y = (int)gmdate('Y',$t); $m = (int)gmdate('n',$t);
+        if ($m < 4) return sprintf('%d-%02d', $y-1, ($y%100));
+        return sprintf('%d-%02d', $y, (($y+1)%100));
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Payments/WebhookController.php
+++ b/wp-content/plugins/fa-fundraising/src/Payments/WebhookController.php
@@ -1,0 +1,222 @@
+<?php
+namespace FA\Fundraising\Payments;
+
+use WP_Error;
+
+if (!defined('ABSPATH')) exit;
+
+class WebhookController {
+    public function init(): void {
+        add_action('rest_api_init', function(){
+            register_rest_route('faf/v1','/webhook/razorpay',[
+                'methods'=>'POST',
+                'callback'=>[$this,'handle'],
+                'permission_callback'=>'__return_true'
+            ]);
+        });
+    }
+
+    public function handle(\WP_REST_Request $req) {
+        $payload = $req->get_body();
+        $sig = $_SERVER['HTTP_X_RAZORPAY_SIGNATURE'] ?? '';
+        try {
+            (new RazorpayService())->verify_webhook($payload, $sig);
+        } catch (\Throwable $e) {
+            return new WP_Error('sig','Invalid signature',['status'=>401]);
+        }
+
+        $event = json_decode($payload, true);
+        if (!$event || empty($event['event']) || empty($event['payload'])) return ['ok'=>true];
+
+        $event_id = $event['event'] . ':' . ($event['payload']['payment']['entity']['id'] ?? $event['payload']['order']['entity']['id'] ?? $event['payload']['subscription']['entity']['id'] ?? wp_generate_uuid4());
+
+        if (!$this->lock_event($event_id, 'razorpay')) {
+            return ['ok'=>true,'skipped'=>'duplicate'];
+        }
+
+        $type = $event['event'];
+
+        switch ($type) {
+            case 'payment.captured':
+                $this->on_payment_captured($event['payload']['payment']['entity']);
+                break;
+            case 'payment.failed':
+                $this->on_payment_failed($event['payload']['payment']['entity']);
+                break;
+            case 'order.paid':
+                // optional; usually payment.captured already arrives
+                break;
+            case 'subscription.charged':
+                $this->on_subscription_charged($event['payload']['payment']['entity'], $event['payload']['subscription']['entity']);
+                break;
+            case 'subscription.halted':
+            case 'subscription.cancelled':
+            case 'subscription.paused':
+            case 'subscription.completed':
+                $this->on_subscription_status($event['payload']['subscription']['entity']);
+                break;
+            default:
+                // ignore others for now
+                break;
+        }
+
+        $this->unlock_event($event_id, 'ok', $payload);
+        return ['ok'=>true];
+    }
+
+    private function on_payment_captured(array $p): void {
+        global $wpdb;
+        $don = $wpdb->prefix.'fa_donations';
+
+        $payment_id = sanitize_text_field($p['id'] ?? '');
+        $order_id   = sanitize_text_field($p['order_id'] ?? '');
+        $amount     = ((int)($p['amount'] ?? 0)) / 100;
+        $currency   = sanitize_text_field($p['currency'] ?? 'INR');
+        $email      = sanitize_email($p['email'] ?? ($p['contact'] ?? ''));
+        $notes      = is_array($p['notes'] ?? null) ? $p['notes'] : [];
+
+        // ensure donor user
+        $user_id = 0;
+        if (!empty($notes['user_id'])) $user_id = (int)$notes['user_id'];
+        if (!$user_id && $email){
+            $u = get_user_by('email', $email);
+            if ($u) $user_id = (int)$u->ID;
+        }
+
+        // skip if already inserted
+        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $don WHERE razorpay_payment_id=%s", $payment_id));
+        if ($exists) return;
+
+        $type = sanitize_text_field($notes['type'] ?? 'general');
+        $orphan_id = isset($notes['orphan_id']) ? (int)$notes['orphan_id'] : null;
+        $cause_id  = isset($notes['cause_id']) ? (int)$notes['cause_id']  : null;
+
+        $name = sanitize_text_field($notes['donor_name'] ?? '');
+        $phone= preg_replace('/[^0-9+]/','', (string)($notes['phone'] ?? ''));
+
+        $fy = RazorpayService::fy_from_date(gmdate('Y-m-d'));
+        $receipt_no = $this->issue_receipt_no($fy);
+
+        $wpdb->insert($don, [
+            'created_at' => current_time('mysql', true),
+            'user_id' => $user_id ?: null,
+            'donor_name' => $name ?: ($email ?: ''),
+            'donor_email'=> $email,
+            'phone' => $phone ?: null,
+            'amount'=> $amount,
+            'currency'=>$currency,
+            'type' => $type,
+            'orphan_id' => $orphan_id ?: null,
+            'cause_id'  => $cause_id ?: null,
+            'razorpay_payment_id'=>$payment_id,
+            'razorpay_order_id'=>$order_id,
+            'status' => 'captured',
+            'financial_year' => $fy,
+            'receipt_no' => $receipt_no,
+            'meta' => maybe_serialize(['notes'=>$notes])
+        ]);
+    }
+
+    private function on_payment_failed(array $p): void {
+        global $wpdb;
+        $don = $wpdb->prefix.'fa_donations';
+        $payment_id = sanitize_text_field($p['id'] ?? '');
+        $order_id   = sanitize_text_field($p['order_id'] ?? '');
+        $email      = sanitize_email($p['email'] ?? ($p['contact'] ?? ''));
+        $notes      = is_array($p['notes'] ?? null) ? $p['notes'] : [];
+        $amount     = ((int)($p['amount'] ?? 0)) / 100;
+        $currency   = sanitize_text_field($p['currency'] ?? 'INR');
+
+        // Insert only if not present
+        $exists = $wpdb->get_var($wpdb->prepare("SELECT id FROM $don WHERE razorpay_payment_id=%s", $payment_id));
+        if ($exists) return;
+
+        $wpdb->insert($don, [
+            'created_at' => current_time('mysql', true),
+            'donor_email'=> $email,
+            'amount'=> $amount,
+            'currency'=>$currency,
+            'type' => sanitize_text_field($notes['type'] ?? 'general'),
+            'orphan_id' => isset($notes['orphan_id'])?(int)$notes['orphan_id']:null,
+            'cause_id'  => isset($notes['cause_id'])?(int)$notes['cause_id']:null,
+            'razorpay_payment_id'=>$payment_id,
+            'razorpay_order_id'=>$order_id,
+            'status' => 'failed',
+            'meta' => maybe_serialize(['error'=>$p['error_reason'] ?? '', 'notes'=>$notes])
+        ]);
+    }
+
+    private function on_subscription_charged(array $payment, array $sub): void {
+        // treat like captured donation + update subscriptions table
+        $this->on_payment_captured($payment);
+
+        global $wpdb;
+        $table = $wpdb->prefix.'fa_subscriptions';
+        $sid = sanitize_text_field($sub['id'] ?? '');
+        $status = sanitize_text_field($sub['status'] ?? 'active');
+        $cur_start = !empty($sub['current_start']) ? gmdate('Y-m-d H:i:s', (int)$sub['current_start']) : null;
+        $cur_end   = !empty($sub['current_end'])   ? gmdate('Y-m-d H:i:s', (int)$sub['current_end'])   : null;
+
+        $row = $wpdb->get_row($wpdb->prepare("SELECT id FROM $table WHERE razorpay_subscription_id=%s", $sid));
+        $notes = is_array($sub['notes'] ?? null) ? $sub['notes'] : [];
+        $user_id = !empty($notes['user_id']) ? (int)$notes['user_id'] : 0;
+        $email = !empty($notes['donor_email']) ? sanitize_email($notes['donor_email']) : '';
+
+        if ($row) {
+            $wpdb->update($table, [
+                'status'=>$status,
+                'current_start'=>$cur_start,
+                'current_end'=>$cur_end
+            ], ['id'=>$row->id]);
+        } else {
+            $wpdb->insert($table, [
+                'razorpay_subscription_id'=>$sid,
+                'user_id'=>$user_id ?: null,
+                'donor_email'=>$email ?: null,
+                'status'=>$status,
+                'current_start'=>$cur_start,
+                'current_end'=>$cur_end,
+                'notes'=> maybe_serialize($notes)
+            ]);
+        }
+    }
+
+    private function on_subscription_status(array $sub): void {
+        global $wpdb;
+        $table = $wpdb->prefix.'fa_subscriptions';
+        $sid = sanitize_text_field($sub['id'] ?? '');
+        $status = sanitize_text_field($sub['status'] ?? '');
+        if (!$sid) return;
+        $wpdb->update($table, ['status'=>$status], ['razorpay_subscription_id'=>$sid]);
+    }
+
+    /** Reserve event id; return false if already processed */
+    private function lock_event(string $event_id, string $handler): bool {
+        global $wpdb;
+        $ev = $wpdb->prefix.'fa_events';
+        $ok = $wpdb->insert($ev, [
+            'event_id'=>$event_id,
+            'handler'=>$handler,
+            'status'=>'locked'
+        ]);
+        return (bool)$ok;
+    }
+
+    private function unlock_event(string $event_id, string $status='ok', string $raw=''): void {
+        global $wpdb;
+        $ev = $wpdb->prefix.'fa_events';
+        $wpdb->update($ev, [
+            'processed_at'=> current_time('mysql', true),
+            'status'=>$status,
+            'raw'=> $raw
+        ], ['event_id'=>$event_id]);
+    }
+
+    private function issue_receipt_no(string $fy): string {
+        $opt = 'fa_receipt_seq_'.$fy;
+        $n = (int) get_option($opt, 0);
+        $n++;
+        update_option($opt, $n, false);
+        return sprintf('%s/%06d', $fy, $n);
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Setup/Activator.php
+++ b/wp-content/plugins/fa-fundraising/src/Setup/Activator.php
@@ -138,10 +138,25 @@ class Activator {
             KEY idx_used_exp (used, expires_at)
         ) $charset;";
 
+        $events = $wpdb->prefix . 'fa_events';
+        $sql5 = "CREATE TABLE {$events} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            event_id VARCHAR(191) NOT NULL,
+            handler VARCHAR(64) NOT NULL,
+            processed_at DATETIME NULL,
+            status VARCHAR(20) NOT NULL DEFAULT 'ok',
+            raw LONGTEXT NULL,
+            PRIMARY KEY (id),
+            UNIQUE KEY uniq_event (event_id),
+            KEY idx_handler (handler)
+        ) $charset;";
+
         dbDelta($sql1);
         dbDelta($sql2);
         dbDelta($sql3);
         dbDelta($sql4);
+        dbDelta($sql5);
     }
 
     private static function add_roles_caps(): void


### PR DESCRIPTION
## Summary
- add Razorpay keys and org details admin settings
- integrate Razorpay service with checkout order API
- handle Razorpay webhooks with idempotent event logging

## Testing
- `php -l src/Setup/Activator.php`
- `php -l src/Admin/Settings.php`
- `php -l src/Payments/RazorpayService.php`
- `php -l src/Api/CheckoutController.php`
- `php -l src/Payments/WebhookController.php`
- `composer validate --strict`
- `composer update` *(fails: curl error 56 CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b182caff588325821c31d2dd54f678