### PR TITLE
Add Orphan/Cause CPTs, directory REST and donation widgets

### DIFF
--- a/wp-content/plugins/fa-fundraising/src/Api/DirectoryController.php
+++ b/wp-content/plugins/fa-fundraising/src/Api/DirectoryController.php
@@ -1,0 +1,141 @@
+<?php
+namespace FA\Fundraising\Api;
+
+if (!defined('ABSPATH')) exit;
+
+class DirectoryController {
+    public function init(): void {
+        add_action('rest_api_init', function(){
+            register_rest_route('faf/v1','/orphans',[
+                'methods'=>'GET',
+                'callback'=>[$this,'orphans'],
+                'permission_callback'=>'__return_true'
+            ]);
+            register_rest_route('faf/v1','/orphans/(?P<id>\d+)',[
+                'methods'=>'GET',
+                'callback'=>[$this,'orphan_single'],
+                'permission_callback'=>'__return_true'
+            ]);
+            register_rest_route('faf/v1','/causes',[
+                'methods'=>'GET',
+                'callback'=>[$this,'causes'],
+                'permission_callback'=>'__return_true'
+            ]);
+            register_rest_route('faf/v1','/causes/(?P<id>\d+)',[
+                'methods'=>'GET',
+                'callback'=>[$this,'cause_single'],
+                'permission_callback'=>'__return_true'
+            ]);
+        });
+    }
+
+    public function orphans(\WP_REST_Request $r){
+        $page = max(1,(int)$r->get_param('page'));
+        $per  = min(50,max(1,(int)($r->get_param('per_page')?:12)));
+        $args = [
+            'post_type'=>'fa_orphan',
+            'post_status'=>'publish',
+            'paged'=>$page,
+            'posts_per_page'=>$per,
+        ];
+
+        if ($s = sanitize_text_field($r->get_param('search'))) $args['s'] = $s;
+
+        if ($d = sanitize_text_field($r->get_param('district'))) {
+            $args['tax_query'] = [[
+                'taxonomy'=>'fa_district','field'=>'name','terms'=>$d
+            ]];
+        }
+
+        $meta_query = [];
+        if ($st = sanitize_text_field($r->get_param('status'))) {
+            $meta_query[] = ['key'=>'fa_status','value'=>$st,'compare'=>'='];
+        }
+        $amin = (int)$r->get_param('age_min'); $amax = (int)$r->get_param('age_max');
+        if ($amin) $meta_query[] = ['key'=>'fa_age','value'=>$amin,'compare'=>'>=','type'=>'NUMERIC'];
+        if ($amax) $meta_query[] = ['key'=>'fa_age','value'=>$amax,'compare'=>'<=','type'=>'NUMERIC'];
+        if ($meta_query) $args['meta_query'] = $meta_query;
+
+        $q = new \WP_Query($args);
+        $items = [];
+        foreach ($q->posts as $p) {
+            $items[] = $this->orphan_payload($p->ID);
+        }
+        return [
+            'ok'=>true,
+            'items'=>$items,
+            'page'=>$page,
+            'per_page'=>$per,
+            'total'=>(int)$q->found_posts
+        ];
+    }
+
+    public function orphan_single(\WP_REST_Request $r){
+        $id = (int)$r->get_param('id');
+        if (!$id || get_post_type($id)!=='fa_orphan' || get_post_status($id)!=='publish')
+            return new \WP_Error('not_found','Not found',['status'=>404]);
+        return ['ok'=>true,'item'=>$this->orphan_payload($id)];
+    }
+
+    private function orphan_payload(int $id): array {
+        $dists = wp_get_post_terms($id,'fa_district', ['fields'=>'names']);
+        return [
+            'id'=>$id,
+            'name'=>get_the_title($id),
+            'excerpt'=>wp_strip_all_tags(get_the_excerpt($id)),
+            'image'=> get_the_post_thumbnail_url($id,'medium') ?: '',
+            'districts'=>$dists,
+            'age'=> (int)get_post_meta($id,'fa_age',true),
+            'gender'=> (string)get_post_meta($id,'fa_gender',true),
+            'monthly_cost'=> (float)get_post_meta($id,'fa_monthly_cost',true),
+            'slots_total'=> (int)get_post_meta($id,'fa_slots_total',true),
+            'slots_filled'=> (int)get_post_meta($id,'fa_slots_filled',true),
+            'status'=> (string)get_post_meta($id,'fa_status',true) ?: 'unsponsored',
+        ];
+    }
+
+    public function causes(\WP_REST_Request $r){
+        $page = max(1,(int)$r->get_param('page'));
+        $per  = min(50,max(1,(int)($r->get_param('per_page')?:12)));
+        $args = [
+            'post_type'=>'fa_cause',
+            'post_status'=>'publish',
+            'paged'=>$page,
+            'posts_per_page'=>$per,
+        ];
+        if ($s = sanitize_text_field($r->get_param('search'))) $args['s'] = $s;
+        if (null !== ($active = $r->get_param('active'))) {
+            $args['meta_query'][] = ['key'=>'fa_active','value' => (int)!!$active, 'compare'=>'='];
+        }
+        $q = new \WP_Query($args);
+        $items = [];
+        foreach ($q->posts as $p) {
+            $id = $p->ID;
+            $items[] = [
+                'id'=>$id,
+                'title'=>get_the_title($id),
+                'excerpt'=>wp_strip_all_tags(get_the_excerpt($id)),
+                'image'=> get_the_post_thumbnail_url($id,'medium') ?: '',
+                'goal'=> (float)get_post_meta($id,'fa_goal_amount',true),
+                'raised'=> (float)get_post_meta($id,'fa_raised_amount',true),
+                'active'=> (bool)get_post_meta($id,'fa_active',true),
+            ];
+        }
+        return ['ok'=>true,'items'=>$items,'page'=>$page,'per_page'=>$per,'total'=>(int)$q->found_posts];
+    }
+
+    public function cause_single(\WP_REST_Request $r){
+        $id = (int)$r->get_param('id');
+        if (!$id || get_post_type($id)!=='fa_cause' || get_post_status($id)!=='publish')
+            return new \WP_Error('not_found','Not found',['status'=>404]);
+        $item = [
+            'id'=>$id,
+            'title'=>get_the_title($id),
+            'content'=>wp_kses_post(get_post_field('post_content',$id)),
+            'goal'=> (float)get_post_meta($id,'fa_goal_amount',true),
+            'raised'=> (float)get_post_meta($id,'fa_raised_amount',true),
+            'active'=> (bool)get_post_meta($id,'fa_active',true),
+        ];
+        return ['ok'=>true,'item'=>$item];
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Bootstrap.php
+++ b/wp-content/plugins/fa-fundraising/src/Bootstrap.php
@@ -11,16 +11,21 @@ class Bootstrap {
             load_plugin_textdomain('fa-fundraising', false, dirname(plugin_basename(FAF_FILE)).'/languages');
         });
 
-        // Shortcodes (placeholders for now)
+        // Shortcodes
         (new \FA\Fundraising\Shortcodes\DonorShortcodes())->register();
+        (new \FA\Fundraising\Shortcodes\FundraisingShortcodes())->register();
 
         (new \FA\Fundraising\Auth\Routes())->init();
 
         (new \FA\Fundraising\Api\StatsController())->init();
         (new \FA\Fundraising\Api\DonationController())->init();
         (new \FA\Fundraising\Api\CheckoutController())->init();
+        (new \FA\Fundraising\Api\DirectoryController())->init();
         (new \FA\Fundraising\Admin\Settings())->init();
         (new \FA\Fundraising\Payments\WebhookController())->init();
+        (new \FA\Fundraising\CPT\Taxonomies())->init();
+        (new \FA\Fundraising\CPT\Orphan())->init();
+        (new \FA\Fundraising\CPT\Cause())->init();
 
         (new \FA\Fundraising\Widgets\Elementor\Plugin())->init();
 

--- a/wp-content/plugins/fa-fundraising/src/CPT/Cause.php
+++ b/wp-content/plugins/fa-fundraising/src/CPT/Cause.php
@@ -1,0 +1,55 @@
+<?php
+namespace FA\Fundraising\CPT;
+
+if (!defined('ABSPATH')) exit;
+
+class Cause {
+    public function init(): void {
+        add_action('init', [$this, 'register']);
+        add_action('init', [$this, 'register_meta']);
+        add_filter('manage_fa_cause_posts_columns', [$this,'cols']);
+        add_action('manage_fa_cause_posts_custom_column', [$this,'coldata'], 10, 2);
+    }
+
+    public function register(): void {
+        register_post_type('fa_cause', [
+            'label' => __('Causes','fa-fundraising'),
+            'public' => true,
+            'show_in_rest' => true,
+            'supports' => ['title','editor','thumbnail','excerpt'],
+            'menu_icon' => 'dashicons-megaphone',
+            'rewrite' => ['slug'=>'cause'],
+        ]);
+    }
+
+    public function register_meta(): void {
+        $meta = [
+            'fa_goal_amount'   => ['type'=>'number','default'=>0],
+            'fa_raised_amount' => ['type'=>'number','default'=>0],
+            'fa_banner'        => ['type'=>'string'],
+            'fa_active'        => ['type'=>'boolean','default'=>true],
+        ];
+        foreach ($meta as $k=>$schema) {
+            register_post_meta('fa_cause', $k, array_merge([
+                'single'=>true,
+                'show_in_rest'=>true,
+                'auth_callback'=>fn()=> current_user_can('edit_posts'),
+                'sanitize_callback'=>null
+            ], $schema));
+        }
+    }
+
+    public function cols($cols){
+        $cols['fa_goal'] = __('Goal','fa-fundraising');
+        $cols['fa_raised'] = __('Raised','fa-fundraising');
+        $cols['fa_active'] = __('Active','fa-fundraising');
+        return $cols;
+    }
+    public function coldata($col, $post_id){
+        switch($col){
+            case 'fa_goal': echo '₹'.number_format((float)get_post_meta($post_id,'fa_goal_amount',true)); break;
+            case 'fa_raised': echo '₹'.number_format((float)get_post_meta($post_id,'fa_raised_amount',true)); break;
+            case 'fa_active': echo get_post_meta($post_id,'fa_active',true) ? 'Yes' : 'No'; break;
+        }
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/CPT/Orphan.php
+++ b/wp-content/plugins/fa-fundraising/src/CPT/Orphan.php
@@ -1,0 +1,66 @@
+<?php
+namespace FA\Fundraising\CPT;
+
+if (!defined('ABSPATH')) exit;
+
+class Orphan {
+    public function init(): void {
+        add_action('init', [$this, 'register']);
+        add_action('init', [$this, 'register_meta']);
+        add_filter('manage_fa_orphan_posts_columns', [$this,'cols']);
+        add_action('manage_fa_orphan_posts_custom_column', [$this,'coldata'], 10, 2);
+    }
+
+    public function register(): void {
+        register_post_type('fa_orphan', [
+            'label' => __('Orphans','fa-fundraising'),
+            'public' => true,
+            'show_in_rest' => true,
+            'supports' => ['title','editor','thumbnail','excerpt'],
+            'menu_icon' => 'dashicons-groups',
+            'rewrite' => ['slug'=>'orphan'],
+        ]);
+    }
+
+    public function register_meta(): void {
+        $meta = [
+            'fa_age'             => ['type'=>'integer'],
+            'fa_gender'          => ['type'=>'string'],
+            'fa_dob'             => ['type'=>'string'],
+            'fa_school'          => ['type'=>'string'],
+            'fa_grade'           => ['type'=>'string'],
+            'fa_story'           => ['type'=>'string'],
+            'fa_monthly_cost'    => ['type'=>'number', 'default'=>1500],
+            'fa_slots_total'     => ['type'=>'integer','default'=>1],
+            'fa_slots_filled'    => ['type'=>'integer','default'=>0],
+            'fa_status'          => ['type'=>'string', 'default'=>'unsponsored'],
+        ];
+        foreach ($meta as $k=>$schema) {
+            register_post_meta('fa_orphan', $k, array_merge([
+                'single'=>true,
+                'show_in_rest'=>true,
+                'auth_callback'=>fn()=> current_user_can('edit_posts'),
+                'sanitize_callback'=>null
+            ], $schema));
+        }
+    }
+
+    public function cols($cols){
+        $cols['fa_age'] = __('Age','fa-fundraising');
+        $cols['fa_cost'] = __('Monthly Cost','fa-fundraising');
+        $cols['fa_slots'] = __('Slots','fa-fundraising');
+        $cols['fa_status'] = __('Status','fa-fundraising');
+        return $cols;
+    }
+    public function coldata($col, $post_id){
+        switch($col){
+            case 'fa_age': echo esc_html(get_post_meta($post_id,'fa_age',true)); break;
+            case 'fa_cost': echo '₹'.number_format((float)get_post_meta($post_id,'fa_monthly_cost',true)); break;
+            case 'fa_slots':
+                $t = (int)get_post_meta($post_id,'fa_slots_total',true);
+                $f = (int)get_post_meta($post_id,'fa_slots_filled',true);
+                echo esc_html("$f / $t"); break;
+            case 'fa_status': echo esc_html(get_post_meta($post_id,'fa_status',true) ?: 'unsponsored'); break;
+        }
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/CPT/Taxonomies.php
+++ b/wp-content/plugins/fa-fundraising/src/CPT/Taxonomies.php
@@ -1,0 +1,21 @@
+<?php
+namespace FA\Fundraising\CPT;
+
+if (!defined('ABSPATH')) exit;
+
+class Taxonomies {
+    public function init(): void {
+        add_action('init', [$this, 'district']);
+    }
+
+    public function district(): void {
+        register_taxonomy('fa_district', ['fa_orphan'], [
+            'label' => __('District','fa-fundraising'),
+            'hierarchical' => true,
+            'show_ui' => true,
+            'show_admin_column' => true,
+            'rewrite' => ['slug'=>'district'],
+            'show_in_rest' => true,
+        ]);
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Shortcodes/FundraisingShortcodes.php
+++ b/wp-content/plugins/fa-fundraising/src/Shortcodes/FundraisingShortcodes.php
@@ -1,0 +1,27 @@
+<?php
+namespace FA\Fundraising\Shortcodes;
+
+if (!defined('ABSPATH')) exit;
+
+class FundraisingShortcodes {
+    public function register(): void {
+        add_shortcode('fa_orphan_grid', [$this,'grid']);
+    }
+
+    public function grid($atts){
+        $atts = shortcode_atts(['district'=>'','status'=>'','per_page'=>12], $atts);
+        ob_start();
+        wp_enqueue_script('razorpay-checkout','https://checkout.razorpay.com/v1/checkout.js',[],null,true);
+        $root = esc_js( (function_exists('rest_url') ? rest_url('faf/v1') : site_url('/wp-json/faf/v1')) );
+        ?>
+        <div class="fa-orphan-grid" data-root="<?php echo $root; ?>" data-district="<?php echo esc_attr($atts['district']); ?>" data-status="<?php echo esc_attr($atts['status']); ?>" data-per="<?php echo (int)$atts['per_page']; ?>" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:14px;">
+          <div class="fa-grid-loading" style="grid-column:1/-1;opacity:.7;"><?php esc_html_e('Loading...','fa-fundraising'); ?></div>
+        </div>
+        <script>
+        window.fa_donor_receipts_url = '<?php echo esc_js(get_permalink( (int) get_option('fa_donor_receipts_page_id') )); ?>';
+        (<?php echo file_get_contents(__DIR__.'/../Widgets/Elementor/_orphan_grid_boot.js'); ?>)();
+        </script>
+        <?php
+        return ob_get_clean();
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/DonationCTA.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/DonationCTA.php
@@ -1,0 +1,78 @@
+<?php
+namespace FA\Fundraising\Widgets\Elementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) exit;
+
+class DonationCTA extends Widget_Base {
+    public function get_name(){ return 'fa_donation_cta'; }
+    public function get_title(){ return __('FA Donation CTA','fa-fundraising'); }
+    public function get_icon(){ return 'eicon-button'; }
+    public function get_categories(){ return ['general']; }
+
+    protected function register_controls() {
+        $this->start_controls_section('cfg', ['label'=>__('Settings','fa-fundraising')]);
+        $this->add_control('label', ['label'=>__('Button Label','fa-fundraising'),'type'=>Controls_Manager::TEXT,'default'=>__('Donate Now','fa-fundraising')]);
+        $this->add_control('type', ['label'=>__('Type','fa-fundraising'),'type'=>Controls_Manager::SELECT,
+            'options'=>['general'=>'General','cause'=>'Cause','sponsorship'=>'Sponsorship'], 'default'=>'general']);
+        $this->add_control('cause_id', ['label'=>__('Cause ID (for type=cause)','fa-fundraising'),'type'=>Controls_Manager::NUMBER,'default'=>0]);
+        $this->add_control('orphan_id', ['label'=>__('Orphan ID (for type=sponsorship)','fa-fundraising'),'type'=>Controls_Manager::NUMBER,'default'=>0]);
+        $this->add_control('amount', ['label'=>__('Default Amount (INR)','fa-fundraising'),'type'=>Controls_Manager::NUMBER,'default'=>500]);
+        $this->end_controls_section();
+    }
+
+    protected function render(){
+        wp_enqueue_script('razorpay-checkout','https://checkout.razorpay.com/v1/checkout.js',[],null,true);
+        $label = esc_html($this->get_settings('label'));
+        $type  = esc_attr($this->get_settings('type'));
+        $cause = (int)$this->get_settings('cause_id');
+        $orph  = (int)$this->get_settings('orphan_id');
+        $amt   = (float)$this->get_settings('amount');
+
+        $root = esc_js( (function_exists('rest_url') ? rest_url('faf/v1') : site_url('/wp-json/faf/v1')) );
+        ?>
+        <button class="fa-cta" data-root="<?php echo $root; ?>" data-type="<?php echo $type; ?>" data-cause="<?php echo $cause; ?>" data-orphan="<?php echo $orph; ?>" data-amount="<?php echo $amt; ?>" style="padding:.8rem 1.2rem;border-radius:10px;border:1px solid #111;background:#111;color:#fff;">
+            <?php echo $label; ?>
+        </button>
+        <script>
+        (function(){
+          const btn = document.currentScript.previousElementSibling;
+          btn.addEventListener('click', async ()=>{
+            const root = btn.getAttribute('data-root');
+            const type = btn.getAttribute('data-type');
+            const cause_id = parseInt(btn.getAttribute('data-cause'))||null;
+            const orphan_id = parseInt(btn.getAttribute('data-orphan'))||null;
+            const defAmt = parseFloat(btn.getAttribute('data-amount'))||0;
+
+            const amount = prompt('<?php echo esc_js(__('Enter amount (INR)','fa-fundraising')); ?>', Math.round(defAmt||0)) || '';
+            if (!amount || isNaN(parseFloat(amount))) return;
+
+            const email = prompt('<?php echo esc_js(__('Your email','fa-fundraising')); ?>')||'';
+            if (!email) return;
+            const name = prompt('<?php echo esc_js(__('Your name (optional)','fa-fundraising')); ?>')||'';
+            const phone = prompt('<?php echo esc_js(__('Phone (optional)','fa-fundraising')); ?>')||'';
+
+            const r = await fetch(root + '/checkout/order', {
+              method:'POST', headers:{'Content-Type':'application/json'},
+              body: JSON.stringify({ amount: parseFloat(amount), currency:'INR', type, cause_id, orphan_id, email, name, phone })
+            });
+            const j = await r.json();
+            if (!j.ok) { alert(j.message || 'Error'); return; }
+
+            const options = {
+              key: j.key_id,
+              order_id: j.order.id,
+              name: document.title || 'Future Achievers',
+              prefill: { email, name, contact: phone },
+              handler: function(resp){ window.location.href = '<?php echo esc_url(get_permalink( (int) get_option('fa_donor_receipts_page_id') )); ?>'; }
+            };
+            const rz = new window.Razorpay(options);
+            rz.open();
+          });
+        })();
+        </script>
+        <?php
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/OrphanGrid.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/OrphanGrid.php
@@ -1,0 +1,117 @@
+<?php
+namespace FA\Fundraising\Widgets\Elementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) exit;
+
+class OrphanGrid extends Widget_Base {
+    public function get_name(){ return 'fa_orphan_grid'; }
+    public function get_title(){ return __('FA Orphan Grid','fa-fundraising'); }
+    public function get_icon(){ return 'eicon-posts-grid'; }
+    public function get_categories(){ return ['general']; }
+
+    protected function register_controls() {
+        $this->start_controls_section('content', ['label'=>__('Content','fa-fundraising')]);
+        $this->add_control('district', [
+            'label'=>__('Filter by District (name)','fa-fundraising'),
+            'type'=>Controls_Manager::TEXT, 'default'=>''
+        ]);
+        $this->add_control('status', [
+            'label'=>__('Status','fa-fundraising'),
+            'type'=>Controls_Manager::SELECT,
+            'options'=>[''=>'All','unsponsored'=>'Unsponsored','partial'=>'Partial','full'=>'Full'],
+            'default'=>''
+        ]);
+        $this->add_control('per_page', [
+            'label'=>__('Per Page','fa-fundraising'),
+            'type'=>Controls_Manager::NUMBER, 'default'=>12
+        ]);
+        $this->end_controls_section();
+    }
+
+    protected function render(){
+        wp_enqueue_script('razorpay-checkout','https://checkout.razorpay.com/v1/checkout.js',[],null,true);
+
+        $district = esc_attr($this->get_settings('district') ?: '');
+        $status   = esc_attr($this->get_settings('status') ?: '');
+        $per      = (int)($this->get_settings('per_page') ?: 12);
+
+        $root = esc_js( (function_exists('rest_url') ? rest_url('faf/v1') : site_url('/wp-json/faf/v1')) );
+        ?>
+        <div class="fa-orphan-grid" data-root="<?php echo $root; ?>" data-district="<?php echo $district; ?>" data-status="<?php echo $status; ?>" data-per="<?php echo $per; ?>" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:14px;">
+            <div class="fa-grid-loading" style="grid-column:1/-1;opacity:.7;"><?php esc_html_e('Loading...','fa-fundraising'); ?></div>
+        </div>
+        <script>
+        (function(){
+          const el = document.currentScript.previousElementSibling;
+          const root = el.getAttribute('data-root');
+          const district = el.getAttribute('data-district')||'';
+          const status = el.getAttribute('data-status')||'';
+          const per = el.getAttribute('data-per')||'12';
+          const q = new URLSearchParams({per_page: per});
+          if (district) q.append('district', district);
+          if (status) q.append('status', status);
+
+          fetch(root + '/orphans?' + q.toString())
+            .then(r=>r.json()).then(j=>{
+              el.innerHTML='';
+              if (!j.ok || !j.items?.length) {
+                el.innerHTML = '<div style="grid-column:1/-1;"><?php echo esc_js(__('No orphans found.','fa-fundraising')); ?></div>';
+                return;
+              }
+              j.items.forEach(o=>{
+                const card = document.createElement('div');
+                card.className='fa-card';
+                card.style='border:1px solid #e5e7eb;border-radius:12px;padding:12px;background:#fff;display:flex;flex-direction:column;gap:8px;';
+                card.innerHTML = `
+                  <img src="${o.image||''}" alt="" style="width:100%;height:140px;object-fit:cover;border-radius:8px;">
+                  <div><strong>${o.name}</strong><br><span style="opacity:.7;"><?php echo esc_js(__('Age','fa-fundraising')); ?>: ${o.age||'—'} | ${o.districts?.[0]||''}</span></div>
+                  <div style="font-size:.95rem;"><?php echo esc_js(__('Monthly Cost','fa-fundraising')); ?>: ₹${Math.round(o.monthly_cost||0)}</div>
+                  <div style="opacity:.8;"><?php echo esc_js(__('Slots','fa-fundraising')); ?>: ${o.slots_filled}/${o.slots_total} • ${o.status}</div>
+                  <div style="display:flex;gap:6px;margin-top:6px;">
+                    <button class="fa-donate" data-type="sponsorship" data-orphan="${o.id}" data-amount="${o.monthly_cost||0}" style="flex:1;padding:.6rem 1rem;border-radius:8px;border:1px solid #111;background:#111;color:#fff;"><?php echo esc_js(__('Sponsor Now','fa-fundraising')); ?></button>
+                    <button class="fa-donate" data-type="general" data-amount="${o.monthly_cost||0}" style="padding:.6rem .9rem;border-radius:8px;border:1px solid #e5e7eb;background:#f9fafb;"><?php echo esc_js(__('Donate','fa-fundraising')); ?></button>
+                  </div>
+                `;
+                el.appendChild(card);
+              });
+
+              el.addEventListener('click', async (e)=>{
+                const b = e.target.closest('.fa-donate'); if (!b) return;
+                const type = b.getAttribute('data-type');
+                const orphan_id = b.getAttribute('data-orphan') || null;
+                const amount = prompt('<?php echo esc_js(__('Enter amount (INR)','fa-fundraising')); ?>', Math.round(b.getAttribute('data-amount')||0)) || '';
+                if (!amount || isNaN(parseFloat(amount))) return;
+
+                const email = prompt('<?php echo esc_js(__('Your email','fa-fundraising')); ?>')||'';
+                if (!email) return;
+                const name = prompt('<?php echo esc_js(__('Your name (optional)','fa-fundraising')); ?>')||'';
+                const phone = prompt('<?php echo esc_js(__('Phone (optional)','fa-fundraising')); ?>')||'';
+
+                const r = await fetch(root + '/checkout/order', {
+                  method:'POST', headers:{'Content-Type':'application/json'},
+                  body: JSON.stringify({ amount: parseFloat(amount), currency:'INR', type, orphan_id, email, name, phone })
+                });
+                const j = await r.json();
+                if (!j.ok) { alert(j.message || 'Error'); return; }
+
+                const options = {
+                  key: j.key_id,
+                  order_id: j.order.id,
+                  name: document.title || 'Future Achievers',
+                  prefill: { email: email, name: name, contact: phone },
+                  handler: function (resp) {
+                    window.location.href = '<?php echo esc_url(get_permalink( (int) get_option('fa_donor_receipts_page_id') )); ?>';
+                  }
+                };
+                const rz = new window.Razorpay(options);
+                rz.open();
+              });
+            })
+        })();
+        </script>
+        <?php
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/Plugin.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/Plugin.php
@@ -8,8 +8,12 @@ class Plugin {
         add_action('elementor/widgets/register', function($widgets_manager){
             require_once __DIR__.'/DonorDashboard.php';
             require_once __DIR__.'/ReceiptsTable.php';
+            require_once __DIR__.'/OrphanGrid.php';
+            require_once __DIR__.'/DonationCTA.php';
             $widgets_manager->register(new DonorDashboard());
             $widgets_manager->register(new ReceiptsTable());
+            $widgets_manager->register(new OrphanGrid());
+            $widgets_manager->register(new DonationCTA());
         });
     }
 }

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/_orphan_grid_boot.js
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/_orphan_grid_boot.js
@@ -1,0 +1,69 @@
+function(){
+  const el = document.currentScript.previousElementSibling;
+  const root = el.getAttribute('data-root');
+  const district = el.getAttribute('data-district')||'';
+  const status = el.getAttribute('data-status')||'';
+  const per = el.getAttribute('data-per')||'12';
+  const q = new URLSearchParams({per_page: per});
+  if (district) q.append('district', district);
+  if (status) q.append('status', status);
+
+  fetch(root + '/orphans?' + q.toString())
+    .then(r=>r.json()).then(j=>{
+      el.innerHTML='';
+      if (!j.ok || !j.items?.length) {
+        el.innerHTML = '<div style="grid-column:1/-1;">No orphans found.</div>';
+        return;
+      }
+      j.items.forEach(o=>{
+        const card = document.createElement('div');
+        card.className='fa-card';
+        card.style='border:1px solid #e5e7eb;border-radius:12px;padding:12px;background:#fff;display:flex;flex-direction:column;gap:8px;';
+        card.innerHTML = `
+          <img src="${o.image||''}" alt="" style="width:100%;height:140px;object-fit:cover;border-radius:8px;">
+          <div><strong>${o.name}</strong><br><span style="opacity:.7;">Age: ${o.age||'—'} | ${o.districts?.[0]||''}</span></div>
+          <div style="font-size:.95rem;">Monthly Cost: ₹${Math.round(o.monthly_cost||0)}</div>
+          <div style="opacity:.8;">Slots: ${o.slots_filled}/${o.slots_total} • ${o.status}</div>
+          <div style="display:flex;gap:6px;margin-top:6px;">
+            <button class="fa-donate" data-type="sponsorship" data-orphan="${o.id}" data-amount="${o.monthly_cost||0}" style="flex:1;padding:.6rem 1rem;border-radius:8px;border:1px solid #111;background:#111;color:#fff;">Sponsor Now</button>
+            <button class="fa-donate" data-type="general" data-amount="${o.monthly_cost||0}" style="padding:.6rem .9rem;border-radius:8px;border:1px solid #e5e7eb;background:#f9fafb;">Donate</button>
+          </div>
+        `;
+        el.appendChild(card);
+      });
+
+      el.addEventListener('click', async (e)=>{
+        const b = e.target.closest('.fa-donate'); if (!b) return;
+        const type = b.getAttribute('data-type');
+        const orphan_id = b.getAttribute('data-orphan') || null;
+        const amount = prompt('Enter amount (INR)', Math.round(b.getAttribute('data-amount')||0)) || '';
+        if (!amount || isNaN(parseFloat(amount))) return;
+
+        const email = prompt('Your email')||'';
+        if (!email) return;
+        const name = prompt('Your name (optional)')||'';
+        const phone = prompt('Phone (optional)')||'';
+
+        const r = await fetch(root + '/checkout/order', {
+          method:'POST', headers:{'Content-Type':'application/json'},
+          body: JSON.stringify({ amount: parseFloat(amount), currency:'INR', type, orphan_id, email, name, phone })
+        });
+        const j = await r.json();
+        if (!j.ok) { alert(j.message || 'Error'); return; }
+
+        const options = {
+          key: j.key_id,
+          order_id: j.order.id,
+          name: document.title || 'Future Achievers',
+          prefill: { email: email, name: name, contact: phone },
+          handler: function () {
+            if (window.fa_donor_receipts_url) {
+              window.location.href = window.fa_donor_receipts_url;
+            }
+          }
+        };
+        const rz = new window.Razorpay(options);
+        rz.open();
+      });
+    })
+}


### PR DESCRIPTION
## Summary
- add district taxonomy plus Orphan and Cause custom post types with metadata
- expose directory REST endpoints for listing/filtering orphans and causes
- introduce Elementor widgets and shortcode for grids and donation CTAs

## Testing
- `php -l src/CPT/Taxonomies.php src/CPT/Orphan.php src/CPT/Cause.php src/Api/DirectoryController.php src/Widgets/Elementor/OrphanGrid.php src/Widgets/Elementor/DonationCTA.php src/Shortcodes/FundraisingShortcodes.php src/Widgets/Elementor/Plugin.php`
- `php -l src/Bootstrap.php`


------
https://chatgpt.com/codex/tasks/task_e_68b1886ea2fc8325bfef7457a17cb44b