### PR TITLE
Add public donation verification and widgets

### DIFF
--- a/wp-content/plugins/fa-fundraising/src/Bootstrap.php
+++ b/wp-content/plugins/fa-fundraising/src/Bootstrap.php
@@ -14,6 +14,7 @@ class Bootstrap {
         // Shortcodes
         (new \FA\Fundraising\Shortcodes\DonorShortcodes())->register();
         (new \FA\Fundraising\Shortcodes\FundraisingShortcodes())->register();
+        (new \FA\Fundraising\Shortcodes\VerifyShortcode())->register();
 
         (new \FA\Fundraising\Auth\Routes())->init();
 

--- a/wp-content/plugins/fa-fundraising/src/Shortcodes/VerifyShortcode.php
+++ b/wp-content/plugins/fa-fundraising/src/Shortcodes/VerifyShortcode.php
@@ -1,0 +1,63 @@
+<?php
+namespace FA\Fundraising\Shortcodes;
+
+if (!defined('ABSPATH')) exit;
+
+class VerifyShortcode {
+    public function register(): void {
+        add_shortcode('fa_verify_receipt', [$this,'render']);
+    }
+
+    public function render($atts = []) {
+        ob_start(); ?>
+        <div class="fa-card" style="border:1px solid #e5e7eb;border-radius:12px;padding:16px;background:#fff;max-width:640px;">
+            <h3 style="margin-top:0;"><?php esc_html_e('Verify Receipt','fa-fundraising'); ?></h3>
+            <p class="fa-muted" style="opacity:.8;"><?php esc_html_e('Enter your Razorpay Payment ID or Receipt Number to verify.','fa-fundraising'); ?></p>
+            <form id="fa-vf" style="display:grid;gap:10px;">
+                <input type="text" id="vf-input" placeholder="<?php esc_attr_e('Payment ID (pay_...) or Receipt No (YYYY-YY/000123)','fa-fundraising'); ?>" style="padding:.6rem;border:1px solid #cbd5e1;border-radius:8px;">
+                <button class="fa-btn" type="submit" style="padding:.6rem 1rem;border-radius:8px;border:1px solid #111;background:#111;color:#fff;"><?php esc_html_e('Verify','fa-fundraising'); ?></button>
+            </form>
+            <div id="vf-out" style="margin-top:12px;"></div>
+        </div>
+        <script>
+        (function(){
+          const form = document.getElementById('fa-vf');
+          const out  = document.getElementById('vf-out');
+          const api  = (p)=> (window.wpApiSettings?.root || '/wp-json/') + 'faf/v1' + p;
+
+          form.addEventListener('submit', async (e)=>{
+            e.preventDefault();
+            out.textContent = '<?php echo esc_js(__('Checking…','fa-fundraising')); ?>';
+            const v = document.getElementById('vf-input').value.trim();
+            if (!v) { out.textContent=''; return; }
+
+            const q = new URLSearchParams();
+            if (v.startsWith('pay_')) q.append('payment_id', v);
+            else q.append('receipt_no', v);
+
+            try{
+              const r = await fetch(api('/verify/receipt?'+q.toString()));
+              const j = await r.json();
+              if (!j.ok) throw new Error(j.message || 'Not found');
+
+              const a = new Intl.NumberFormat(undefined,{style:'currency',currency:(j.receipt.currency||'INR'),maximumFractionDigits:0}).format(j.receipt.amount||0);
+              const date = new Date((j.receipt.date||'')+'Z').toLocaleString();
+              out.innerHTML = `
+                <div class="fa-card" style="border:1px dashed #e5e7eb;border-radius:10px;padding:10px;background:#fafafa;">
+                  <div><strong><?php echo esc_js(__('Valid Receipt','fa-fundraising')); ?></strong></div>
+                  <div><?php echo esc_js(__('Receipt No','fa-fundraising')); ?>: ${j.receipt.receipt_no || '—'}</div>
+                  <div><?php echo esc_js(__('Donor','fa-fundraising')); ?>: ${j.receipt.donor_display}</div>
+                  <div><?php echo esc_js(__('Amount','fa-fundraising')); ?>: ${a}</div>
+                  <div><?php echo esc_js(__('Date','fa-fundraising')); ?>: ${date}</div>
+                  <div class="fa-muted" style="margin-top:6px;opacity:.8;"><?php echo esc_js(get_bloginfo('name')); ?></div>
+                </div>`;
+            }catch(e){
+              out.innerHTML = `<div style="color:#b91c1c;"><?php echo esc_js(__('No matching receipt found. Please check the ID/number.','fa-fundraising')); ?></div>`;
+            }
+          });
+        })();
+        </script>
+        <?php
+        return ob_get_clean();
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/CauseProgress.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/CauseProgress.php
@@ -1,0 +1,53 @@
+<?php
+namespace FA\Fundraising\Widgets\Elementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) exit;
+
+class CauseProgress extends Widget_Base {
+    public function get_name(){ return 'fa_cause_progress'; }
+    public function get_title(){ return __('FA Cause Progress','fa-fundraising'); }
+    public function get_icon(){ return 'eicon-skill-bar'; }
+    public function get_categories(){ return ['general']; }
+
+    protected function register_controls() {
+        $this->start_controls_section('cfg', ['label'=>__('Settings','fa-fundraising')]);
+        $this->add_control('cause_id', ['label'=>__('Cause ID (leave 0 to use current post)','fa-fundraising'),'type'=>Controls_Manager::NUMBER,'default'=>0]);
+        $this->add_control('show_numbers', ['label'=>__('Show Numbers'),'type'=>Controls_Manager::SWITCHER,'default'=>'yes']);
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        $cid = (int)($this->get_settings('cause_id') ?: 0);
+        if (!$cid && get_post_type() === 'fa_cause') $cid = get_the_ID();
+        if (!$cid) { echo '<div>'.esc_html__('Select a Cause','fa-fundraising').'</div>'; return; }
+
+        $goal = (float)get_post_meta($cid,'fa_goal_amount',true);
+        $raised = (float)get_post_meta($cid,'fa_raised_amount',true);
+        $pct = $goal > 0 ? min(100, round(($raised/$goal)*100)) : 0;
+
+        $show = $this->get_settings('show_numbers') === 'yes';
+
+        ?>
+        <div class="fa-card" style="border:1px solid #e5e7eb;border-radius:12px;padding:14px;background:#fff;">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:6px;">
+                <strong><?php echo esc_html(get_the_title($cid)); ?></strong>
+                <?php if ($show): ?>
+                    <span style="opacity:.8;"><?php echo esc_html($pct); ?>%</span>
+                <?php endif; ?>
+            </div>
+            <div style="height:14px;border-radius:999px;background:#f1f5f9;overflow:hidden;">
+                <div style="height:100%;width:<?php echo (int)$pct; ?>%;background:#111;border-radius:999px;transition:width .6s;"></div>
+            </div>
+            <?php if ($show): ?>
+            <div style="display:flex;justify-content:space-between;opacity:.8;margin-top:6px;font-size:.95rem;">
+                <span><?php esc_html_e('Raised','fa-fundraising'); ?>: ₹<?php echo number_format((int)$raised); ?></span>
+                <span><?php esc_html_e('Goal','fa-fundraising'); ?>: ₹<?php echo number_format((int)$goal); ?></span>
+            </div>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+}

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/Plugin.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/Plugin.php
@@ -11,11 +11,15 @@ class Plugin {
             require_once __DIR__.'/OrphanGrid.php';
             require_once __DIR__.'/DonationCTA.php';
             require_once __DIR__.'/SubscriptionCTA.php';
+            require_once __DIR__.'/CauseProgress.php';
+            require_once __DIR__.'/RecentDonors.php';
             $widgets_manager->register(new DonorDashboard());
             $widgets_manager->register(new ReceiptsTable());
             $widgets_manager->register(new OrphanGrid());
             $widgets_manager->register(new DonationCTA());
             $widgets_manager->register(new SubscriptionCTA());
+            $widgets_manager->register(new CauseProgress());
+            $widgets_manager->register(new RecentDonors());
         });
     }
 }

--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/RecentDonors.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/RecentDonors.php
@@ -1,0 +1,69 @@
+<?php
+namespace FA\Fundraising\Widgets\Elementor;
+
+use Elementor\Widget_Base;
+use Elementor\Controls_Manager;
+
+if (!defined('ABSPATH')) exit;
+
+class RecentDonors extends Widget_Base {
+    public function get_name(){ return 'fa_recent_donors'; }
+    public function get_title(){ return __('FA Recent Donors','fa-fundraising'); }
+    public function get_icon(){ return 'eicon-person'; }
+    public function get_categories(){ return ['general']; }
+
+    protected function register_controls() {
+        $this->start_controls_section('cfg', ['label'=>__('Filters','fa-fundraising')]);
+        $this->add_control('type', ['label'=>__('Type'),'type'=>Controls_Manager::SELECT,'default'=>'','options'=>[''=>'All','general'=>'General','cause'=>'Cause','sponsorship'=>'Sponsorship']]);
+        $this->add_control('cause_id', ['label'=>__('Cause ID (optional)','fa-fundraising'),'type'=>Controls_Manager::NUMBER,'default'=>0]);
+        $this->add_control('orphan_id', ['label'=>__('Orphan ID (optional)','fa-fundraising'),'type'=>Controls_Manager::NUMBER,'default'=>0]);
+        $this->add_control('limit', ['label'=>__('Count'),'type'=>Controls_Manager::NUMBER,'default'=>10]);
+        $this->end_controls_section();
+    }
+
+    protected function render() {
+        $root = esc_js( rest_url('faf/v1') );
+        $type = esc_js($this->get_settings('type') ?: '');
+        $cause= (int)$this->get_settings('cause_id');
+        $orph = (int)$this->get_settings('orphan_id');
+        $lim  = (int)($this->get_settings('limit') ?: 10);
+        ?>
+        <div class="fa-card" data-root="<?php echo $root; ?>" data-type="<?php echo $type; ?>" data-cause="<?php echo $cause; ?>" data-orph="<?php echo $orph; ?>" data-limit="<?php echo $lim; ?>" style="border:1px solid #e5e7eb;border-radius:12px;padding:14px;background:#fff;">
+            <h4 style="margin-top:0;"><?php esc_html_e('Recent Donors','fa-fundraising'); ?></h4>
+            <ul id="fa-rd" style="padding-left:1rem;margin:.5rem 0 0;">
+                <li class="fa-muted"><?php esc_html_e('Loading…','fa-fundraising'); ?></li>
+            </ul>
+        </div>
+        <script>
+        (function(){
+          const el = document.currentScript.previousElementSibling;
+          const root  = el.getAttribute('data-root');
+          const type  = el.getAttribute('data-type')||'';
+          const cause = el.getAttribute('data-cause')||'0';
+          const orph  = el.getAttribute('data-orph')||'0';
+          const limit = el.getAttribute('data-limit')||'10';
+          const q = new URLSearchParams({limit});
+          if (type) q.append('type', type);
+          if (parseInt(cause)) q.append('cause_id', cause);
+          if (parseInt(orph))  q.append('orphan_id', orph);
+
+          fetch(root + '/public/recent-donations?' + q.toString())
+            .then(r=>r.json()).then(j=>{
+              const ul = el.querySelector('#fa-rd'); ul.innerHTML='';
+              if (!j.ok || !j.items?.length){
+                ul.innerHTML = '<li class="fa-muted"><?php echo esc_js(__('No donations yet.','fa-fundraising')); ?></li>';
+                return;
+              }
+              j.items.forEach(x=>{
+                const li = document.createElement('li');
+                const d = new Date(x.date+'Z').toLocaleDateString();
+                const amt = new Intl.NumberFormat(undefined,{style:'currency',currency:(x.currency||'INR'),maximumFractionDigits:0}).format(x.amount||0);
+                li.textContent = `${x.donor} — ${amt} (${d})`;
+                ul.appendChild(li);
+              });
+            });
+        })();
+        </script>
+        <?php
+    }
+}


### PR DESCRIPTION
## Summary
- Expose receipt verification by payment ID or receipt number
- Add public recent-donations REST feed
- Introduce Cause Progress and Recent Donors Elementor widgets
- Add receipt verification shortcode

## Testing
- `php -l src/Api/DonationController.php`
- `php -l src/Widgets/Elementor/CauseProgress.php`
- `php -l src/Widgets/Elementor/RecentDonors.php`
- `php -l src/Widgets/Elementor/Plugin.php`
- `php -l src/Shortcodes/VerifyShortcode.php`
- `php -l src/Bootstrap.php`


------
https://chatgpt.com/codex/tasks/task_e_68b260f5fb308325bf94046ebb360f7f