### PR TITLE
Add FA Minimal theme scaffolding

### DIFF
--- a/wp-content/themes/fa-minimal/footer.php
+++ b/wp-content/themes/fa-minimal/footer.php
@@ -1,0 +1,17 @@
+<?php if (!defined('ABSPATH')) exit; ?>
+</main>
+<?php
+if (function_exists('elementor_theme_do_location') && elementor_theme_do_location('footer')) : ?>
+<?php else: ?>
+<footer class="site-footer">
+  <div class="container" style="display:flex;justify-content:space-between;align-items:center;gap:12px;">
+    <div>&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?></div>
+    <div>
+      <a href="<?php echo esc_url(site_url('/verify-receipt')); ?>"><?php esc_html_e('Verify Receipt','fa-minimal'); ?></a>
+    </div>
+  </div>
+</footer>
+<?php endif; ?>
+<?php wp_footer(); ?>
+</body>
+</html>

--- a/wp-content/themes/fa-minimal/functions.php
+++ b/wp-content/themes/fa-minimal/functions.php
@@ -1,0 +1,60 @@
+<?php
+// Exit if accessed directly
+if (!defined('ABSPATH')) exit;
+
+add_action('after_setup_theme', function () {
+    add_theme_support('title-tag');
+    add_theme_support('post-thumbnails');
+    add_theme_support('html5', ['search-form','gallery','caption','style','script']);
+    register_nav_menus(['primary' => __('Primary Menu','fa-minimal')]);
+    // Elementor friendliness
+    add_theme_support('elementor-location-header');
+    add_theme_support('elementor-location-footer');
+});
+
+// Enqueue minimal CSS and small performance tweaks
+add_action('wp_enqueue_scripts', function () {
+    wp_enqueue_style('fa-minimal', get_stylesheet_uri(), [], '1.0.0');
+
+    // DNS Prefetch / Preconnect for Razorpay & CDN
+    add_action('wp_head', function () {
+        echo '<link rel="dns-prefetch" href="//checkout.razorpay.com">'.PHP_EOL;
+        echo '<link rel="preconnect" href="https://checkout.razorpay.com" crossorigin>'.PHP_EOL;
+        echo '<link rel="dns-prefetch" href="//cdn.jsdelivr.net">'.PHP_EOL;
+        echo '<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>'.PHP_EOL;
+    }, 1);
+
+    // Dequeue some defaults for speed (safe in most installs)
+    wp_deregister_style('wp-block-library'); // Gutenberg CSS
+    wp_deregister_style('global-styles');    // theme.json
+}, 9);
+
+// Trim head noise (emojis, oEmbed)
+add_action('init', function () {
+    remove_action('wp_head', 'print_emoji_detection_script', 7);
+    remove_action('admin_print_scripts', 'print_emoji_detection_script');
+    remove_action('wp_print_styles', 'print_emoji_styles');
+    remove_action('admin_print_styles', 'print_emoji_styles');
+    remove_action('wp_head', 'wp_oembed_add_discovery_links');
+    remove_action('wp_head', 'wp_oembed_add_host_js');
+}, 20);
+
+// Place jQuery in footer (front-end) and drop migrate if present
+add_action('wp_enqueue_scripts', function () {
+    if (!is_admin() && wp_script_is('jquery', 'registered')) {
+        wp_deregister_script('jquery');
+        wp_register_script('jquery', includes_url('/js/jquery/jquery.min.js'), [], '3.7.1', true);
+        wp_enqueue_script('jquery');
+        wp_deregister_script('jquery-migrate');
+    }
+}, 100);
+
+// Basic Elementor container width (optional)
+if (!defined('ELEMENTOR_DEFAULT_GENERIC_FONT')) {
+    define('ELEMENTOR_DEFAULT_GENERIC_FONT', 'system-ui');
+}
+
+// Helper: menu fallback
+function fa_minimal_menu_fallback() {
+    echo '<nav class="nav"><a href="'.esc_url(home_url('/')).'">'.esc_html__('Home','fa-minimal').'</a></nav>';
+}

--- a/wp-content/themes/fa-minimal/header.php
+++ b/wp-content/themes/fa-minimal/header.php
@@ -1,0 +1,32 @@
+<?php if (!defined('ABSPATH')) exit; ?>
+<!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+<meta charset="<?php bloginfo('charset'); ?>">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<?php wp_head(); ?>
+</head>
+<body <?php body_class(); ?>>
+<?php
+// If Elementor Theme Builder header exists, render it.
+if (function_exists('elementor_theme_do_location') && elementor_theme_do_location('header')) : ?>
+<?php else: ?>
+<header class="site-header">
+  <div class="container" style="display:flex;align-items:center;justify-content:space-between;gap:16px;">
+    <a class="brand" href="<?php echo esc_url(home_url('/')); ?>"><?php bloginfo('name'); ?></a>
+    <?php
+      if (has_nav_menu('primary')) {
+          wp_nav_menu([
+              'theme_location' => 'primary',
+              'container' => false,
+              'menu_class' => 'nav',
+              'fallback_cb' => 'fa_minimal_menu_fallback'
+          ]);
+      } else {
+          fa_minimal_menu_fallback();
+      }
+    ?>
+  </div>
+</header>
+<?php endif; ?>
+<main class="main container">

--- a/wp-content/themes/fa-minimal/index.php
+++ b/wp-content/themes/fa-minimal/index.php
@@ -1,0 +1,10 @@
+<?php get_header(); ?>
+<?php if (have_posts()): while (have_posts()): the_post(); ?>
+  <article <?php post_class('entry'); ?>>
+    <h1><?php the_title(); ?></h1>
+    <div class="content"><?php the_content(); ?></div>
+  </article>
+<?php endwhile; else: ?>
+  <p><?php esc_html_e('Nothing found.','fa-minimal'); ?></p>
+<?php endif; ?>
+<?php get_footer(); ?>

--- a/wp-content/themes/fa-minimal/page-donor-dashboard.php
+++ b/wp-content/themes/fa-minimal/page-donor-dashboard.php
@@ -1,0 +1,6 @@
+<?php
+/* Template Name: Donor Dashboard */
+get_header(); the_post(); ?>
+<h1><?php the_title(); ?></h1>
+<?php echo do_shortcode('[fa_donor_dashboard]'); ?>
+<?php get_footer(); ?>

--- a/wp-content/themes/fa-minimal/page-donor-receipts.php
+++ b/wp-content/themes/fa-minimal/page-donor-receipts.php
@@ -1,0 +1,6 @@
+<?php
+/* Template Name: Donor Receipts */
+get_header(); the_post(); ?>
+<h1><?php the_title(); ?></h1>
+<?php echo do_shortcode('[fa_receipts]'); ?>
+<?php get_footer(); ?>

--- a/wp-content/themes/fa-minimal/page-orphan-directory.php
+++ b/wp-content/themes/fa-minimal/page-orphan-directory.php
@@ -1,0 +1,16 @@
+<?php
+/* Template Name: Orphan Directory */
+get_header(); the_post(); ?>
+<section class="fa-hero">
+  <h1><?php the_title(); ?></h1>
+  <p class="fa-muted"><?php esc_html_e('Sponsor a child — monthly or one-time.','fa-minimal'); ?></p>
+</section>
+
+<?php
+// Elementor widget or shortcode version — both work.
+// If Elementor page, you can ignore this and build visually.
+// Shortcode grid:
+echo do_shortcode('[fa_orphan_grid per_page="12"]');
+?>
+
+<?php get_footer(); ?>

--- a/wp-content/themes/fa-minimal/page-verify-receipt.php
+++ b/wp-content/themes/fa-minimal/page-verify-receipt.php
@@ -1,0 +1,6 @@
+<?php
+/* Template Name: Verify Receipt */
+get_header(); the_post(); ?>
+<h1><?php the_title(); ?></h1>
+<?php echo do_shortcode('[fa_verify_receipt]'); ?>
+<?php get_footer(); ?>

--- a/wp-content/themes/fa-minimal/single-fa_cause.php
+++ b/wp-content/themes/fa-minimal/single-fa_cause.php
@@ -1,0 +1,29 @@
+<?php
+/* Single template for FA Cause */
+get_header();
+the_post();
+$cid = get_the_ID();
+?>
+<section class="fa-hero">
+  <h1><?php the_title(); ?></h1>
+  <?php if (has_post_thumbnail()) the_post_thumbnail('large', ['style'=>'border-radius:12px;max-width:100%;height:auto;']); ?>
+</section>
+
+<div class="content"><?php the_content(); ?></div>
+
+<div style="display:grid;grid-template-columns:2fr 1fr;gap:16px;margin-top:16px;">
+  <div>
+    <?php echo do_shortcode('[fa_recent_donors type="cause" cause_id="'.$cid.'" limit="8"]'); ?>
+  </div>
+  <aside>
+    <?php
+      // Progress bar + Donation CTA
+      if (class_exists('\\FA\\Fundraising\\Widgets\\Elementor\\CauseProgress')) {
+          echo do_shortcode('[fa_donation_cta type="cause" cause_id="'.$cid.'" amount="500"]');
+      }
+      // Fallback to shortcode if you created one, else keep CTA only:
+      // echo do_shortcode('[fa_cause_progress cause_id="'.$cid.'"]');
+    ?>
+  </aside>
+</div>
+<?php get_footer(); ?>

--- a/wp-content/themes/fa-minimal/style.css
+++ b/wp-content/themes/fa-minimal/style.css
@@ -1,0 +1,21 @@
+/*
+Theme Name: FA Minimal
+Theme URI: https://futureachievers.ngo
+Author: Future Achievers
+Description: Ultra-light Elementor-friendly theme for FA Fundraising.
+Version: 1.0.0
+Text Domain: fa-minimal
+*/
+:root{--fa-max:1200px}
+body{margin:0;font:16px/1.55 system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,"Helvetica Neue",Arial,sans-serif;color:#111;background:#f6f7fb}
+a{color:#111;text-decoration:none}
+a:hover{text-decoration:underline}
+.container{max-width:var(--fa-max);margin:0 auto;padding:18px}
+.site-header{background:#fff;border-bottom:1px solid #e5e7eb;position:sticky;top:0;z-index:50}
+.brand{font-weight:700;font-size:1.1rem}
+.nav{display:flex;gap:14px;flex-wrap:wrap}
+.site-footer{border-top:1px solid #e5e7eb;background:#fff;margin-top:24px}
+.main{min-height:50vh}
+.fa-hero{padding:32px 0}
+.btn{display:inline-block;padding:.6rem 1rem;border-radius:10px;border:1px solid #111;background:#111;color:#fff}
+.btn--ghost{background:#f8fafc;border-color:#e5e7eb;color:#111}


### PR DESCRIPTION
## Summary
- add FA Minimal lightweight theme with CSS and Elementor-friendly hooks
- include templates for orphan directory, donor dashboard, receipts, receipt verification, and single causes

## Testing
- `php -l wp-content/themes/fa-minimal/functions.php`
- `php -l wp-content/themes/fa-minimal/header.php`
- `php -l wp-content/themes/fa-minimal/footer.php`
- `php -l wp-content/themes/fa-minimal/index.php`
- `php -l wp-content/themes/fa-minimal/single-fa_cause.php`
- `php -l wp-content/themes/fa-minimal/page-orphan-directory.php`
- `php -l wp-content/themes/fa-minimal/page-donor-dashboard.php`
- `php -l wp-content/themes/fa-minimal/page-donor-receipts.php`
- `php -l wp-content/themes/fa-minimal/page-verify-receipt.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2627ea680832583e0a5ef13577bae