### PR TITLE
Use donor login shortcode in template

### DIFF
--- a/wp-content/themes/fa-minimal/page-donor-login.php
+++ b/wp-content/themes/fa-minimal/page-donor-login.php
@@ -3,7 +3,6 @@
 get_header(); the_post(); ?>
 <h1><?php the_title(); ?></h1>
 <?php
-$redirect = get_permalink( (int) get_option('fa_donor_dashboard_page_id') );
-wp_login_form(['redirect' => $redirect ?: home_url('/')]);
+echo do_shortcode('[fa_donor_login]');
 ?>
 <?php get_footer(); ?>


### PR DESCRIPTION
## Summary
- Replace wp_login_form with `[fa_donor_login]` shortcode in donor login template

## Testing
- `php -l wp-content/themes/fa-minimal/page-donor-login.php`


------
https://chatgpt.com/codex/tasks/task_e_68b282ccbfa48325a83f2650dd30a141