### PR TITLE
Establish donor login after Razorpay checkout

### DIFF
--- a/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/DonationCTA.php
+++ b/wp-content/plugins/fa-fundraising/src/Widgets/Elementor/DonationCTA.php
@@ -67,8 +67,8 @@ class DonationCTA extends Widget_Base {
               name: document.title || 'Future Achievers',
               prefill: { email, name, contact: phone },
               handler: async function(resp){
-                try{
-                  await fetch((window.wpApiSettings?.root || '/wp-json/')+'faf/v1/checkout/verify', {
+                try {
+                  const vr = await fetch((window.wpApiSettings?.root || '/wp-json/')+'faf/v1/checkout/verify', {
                     method:'POST', headers:{'Content-Type':'application/json'},
                     body: JSON.stringify({
                       order_id: j.order.id,
@@ -77,8 +77,13 @@ class DonationCTA extends Widget_Base {
                       notes: j.order.notes || {}
                     })
                   });
-                }catch(e){}
-                window.location.href = '<?php echo esc_url(get_permalink( (int) get_option('fa_donor_receipts_page_id') )); ?>';
+                  const vj = await vr.json();
+                  if (vj.ok && vj.logged_in) {
+                    window.location.href = '/donor-receipts/';
+                    return;
+                  }
+                } catch(e) {}
+                alert('Payment verified, please log in to view your receipts.');
               }
             };
             const rz = new window.Razorpay(options);


### PR DESCRIPTION
## Summary
- Log donors in when verifying Razorpay checkout and report login status
- Handle verify response in Donation CTA; redirect logged-in donors to receipts and prompt manual login otherwise

## Testing
- `php -l wp-content/plugins/fa-fundraising/src/Api/CheckoutController.php`
- `php -l wp-content/plugins/fa-fundraising/src/Widgets/Elementor/DonationCTA.php`
- `composer validate --no-check-all --strict`


------
https://chatgpt.com/codex/tasks/task_e_68b28d1be14083259031a829c1ad6471