### PR TITLE
Add standalone Razorpay gateway for GiveWP

### DIFF
--- a/wp-content/plugins/givewp-razorpay/class-razorpay-gateway.php
+++ b/wp-content/plugins/givewp-razorpay/class-razorpay-gateway.php
@@ -1,0 +1,76 @@
+<?php
+
+use Give\Donations\Models\Donation;
+use Give\Donations\Models\DonationNote;
+use Give\Donations\ValueObjects\DonationStatus;
+use Give\Framework\Http\Response\Types\RedirectResponse;
+use Give\Framework\PaymentGateways\Commands\PaymentRefunded;
+use Give\Framework\PaymentGateways\PaymentGateway;
+
+/**
+ * Razorpay payment gateway implementation.
+ */
+class RazorpayGateway extends PaymentGateway {
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function id(): string {
+        return 'razorpay';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getId(): string {
+        return self::id();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getName(): string {
+        return __( 'Razorpay', 'givewp-razorpay' );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getPaymentMethodLabel(): string {
+        return __( 'Razorpay', 'givewp-razorpay' );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLegacyFormFieldMarkup( int $formId, array $args ): string {
+        return '<div class="givewp-razorpay-help-text"><p>' . esc_html__( 'Pay securely via Razorpay.', 'givewp-razorpay' ) . '</p></div>';
+    }
+
+    /**
+     * Process the donation with Razorpay.
+     *
+     * This is a stub that immediately marks the donation as complete. Replace
+     * with real Razorpay API integration as needed.
+     */
+    public function createPayment( Donation $donation, $gatewayData ) {
+        $donation->status = DonationStatus::COMPLETE();
+        $donation->gatewayTransactionId = 'razorpay-demo';
+        $donation->save();
+
+        DonationNote::create([
+            'donationId' => $donation->id,
+            'content'    => __( 'Donation processed via Razorpay test gateway.', 'givewp-razorpay' ),
+        ]);
+
+        return new RedirectResponse( give_get_success_page_uri() );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function refundDonation( Donation $donation ): PaymentRefunded {
+        return new PaymentRefunded();
+    }
+}
+

--- a/wp-content/plugins/givewp-razorpay/givewp-razorpay.php
+++ b/wp-content/plugins/givewp-razorpay/givewp-razorpay.php
@@ -1,49 +1,22 @@
 <?php
 /**
  * Plugin Name: GiveWP Razorpay Gateway
- * Description: Adds Razorpay as a payment option for GiveWP donations.
+ * Description: Standalone Razorpay payment gateway for GiveWP donations.
  * Version: 1.0.0
  * Author: Mansour M
  * License: GPL-2.0-or-later
  * Text Domain: givewp-razorpay
  */
 
+// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
-    exit; // Exit if accessed directly.
+    exit;
 }
 
-/**
- * Register Razorpay gateway with GiveWP.
- *
- * @param array $gateways Existing gateways.
- *
- * @return array Modified gateways.
- */
-function givewp_razorpay_register_gateway( $gateways ) {
-    $gateways['razorpay'] = [
-        'admin_label'    => __( 'Razorpay', 'givewp-razorpay' ),
-        'checkout_label' => __( 'Razorpay', 'givewp-razorpay' ),
-    ];
+// Register the Razorpay gateway with GiveWP.
+add_action( 'givewp_register_payment_gateway', static function ( $paymentGatewayRegister ) {
+    require_once __DIR__ . '/class-razorpay-gateway.php';
 
-    return $gateways;
-}
-add_filter( 'give_payment_gateways', 'givewp_razorpay_register_gateway' );
+    $paymentGatewayRegister->registerGateway( RazorpayGateway::class );
+} );
 
-/**
- * Process a Razorpay donation.
- *
- * This is a stub that immediately marks the donation as complete. It should be
- * replaced with real Razorpay integration in future steps.
- *
- * @param array $purchase_data Donation data.
- */
-function givewp_razorpay_process_donation( $purchase_data ) {
-    $payment_id = give_insert_payment( $purchase_data );
-
-    if ( $payment_id ) {
-        give_update_payment_status( $payment_id, 'publish' );
-    }
-
-    return;
-}
-add_action( 'give_gateway_razorpay', 'givewp_razorpay_process_donation' );


### PR DESCRIPTION
## Summary
- add standalone Razorpay GiveWP gateway plugin using Payment Gateway API
- register Razorpay gateway class and stub donation processing

## Testing
- `php -l wp-content/plugins/givewp-razorpay/givewp-razorpay.php`
- `php -l wp-content/plugins/givewp-razorpay/class-razorpay-gateway.php`

------
https://chatgpt.com/codex/tasks/task_e_68b2a73356e4832590b94318d1103d53